### PR TITLE
fix: 🐛 spaces in folder path crashes extension

### DIFF
--- a/src/common/utilities/node/plutil.ts
+++ b/src/common/utilities/node/plutil.ts
@@ -1,6 +1,6 @@
 import {CancellationToken} from 'vscode';
 import {checkOutput} from './child_process';
-import {quoted} from '../string';
+import {dblQuoted, quoted} from '../string';
 
 async function convert(
   input: string,
@@ -23,7 +23,7 @@ async function convert(
   const args = [
     format === 'json' ? format : format === 'plist' ? 'xml1' : 'binary1',
     '-r',
-    input,
+    dblQuoted(input),
     '-o',
     quoted(output),
   ];

--- a/src/common/utilities/string.ts
+++ b/src/common/utilities/string.ts
@@ -3,3 +3,9 @@ export function quoted(str: string): string {
   const isQouted = isSingleQuoted || (str.startsWith('"') && str.endsWith('"'));
   return isQouted ? str : `'${str}'`;
 }
+
+export function dblQuoted(str: string): string {
+  const isDblQuoted = str.startsWith('"') && str.endsWith('"');
+  const isQuoted = isDblQuoted || (str.startsWith("'") && str.endsWith("'"));
+  return isQuoted ? str : `"${str}"`;
+}


### PR DESCRIPTION
Fixes #9 .

E.g. when attempting to open `"/Users/me/Library/Application Support/SourceTree/actions.plist"`:

```
Failed to decode binary plist 'actions.plist'. 
Error: Command failed: /usr/bin/plutil -convert xml1 -r /Users/me/Library/Application Support/SourceTree/actions.plist -o '/Users/me/Library/Application Support/Code/User/workspaceStorage/950fd662d0e88bc1dfde5a071b7966d3/ivhernandez.vscode-plist/bplist/actions.4cd8da8a.plist'
```
