### PR TITLE
fix: 🐛 Fix bug where dates were parsed as local time

### DIFF
--- a/src/core/binary/decoder/binary_plist_decoder.ts
+++ b/src/core/binary/decoder/binary_plist_decoder.ts
@@ -276,12 +276,14 @@ function parseAsString(
     : stringBytes.swap16().toString('utf16le');
 }
 
-const CORE_FOUNDATION_ABSOLUTE_TIME_START = 'January 1 2001 GMT' as const;
+// binary plist dates are seconds since midnight, January 1 2001 GMT ,
+//  whereas JS dates are milliseconds since midnight, January 1 1970 GMT .
+const CORE_FOUNDATION_ABSOLUTE_TIME_START = Date.parse(
+  '01 Jan 2001 00:00:00 GMT'
+);
 function parseAsDate(bytes: Buffer, offset: number): Date {
   const cfAbsoluteTime = bytes.readDoubleBE(offset);
-  const date = new Date(CORE_FOUNDATION_ABSOLUTE_TIME_START);
-  date.setSeconds(date.getSeconds() + cfAbsoluteTime);
-  return date;
+  return new Date(CORE_FOUNDATION_ABSOLUTE_TIME_START + cfAbsoluteTime * 1000);
 }
 
 function parseContainerReference(

--- a/src/core/textual/model/plist_parser.test.ts
+++ b/src/core/textual/model/plist_parser.test.ts
@@ -59,7 +59,7 @@ describe('Plist Parser', () => {
     expect(actual).toEqual(expected);
   });
 
-  const FAKE_DATE = new Date('1995-07-30T03:24:00');
+  const FAKE_DATE = new Date('1995-07-30T03:24:00-04:00');
   it('date', () => {
     const actual = parseObjectAndReturnRootChildren({dateKey: FAKE_DATE});
     const expected: PlistEntry[] = [

--- a/src/core/textual/plist_webview_controller.test.ts
+++ b/src/core/textual/plist_webview_controller.test.ts
@@ -186,13 +186,13 @@ describe('Plist Webview Controller', () => {
     });
     const key = memento.oneAndOnlyKey;
     if (!expectToBeDefined(key)) return;
-    expect(memento.get(key)).toEqual({first: 30});
+    expect(memento.get(key)).toEqual({first: '30'});
 
     webview.postWebviewMessage({
       command: 'webviewStateChanged',
       payload: {key: 'columnWidths', newValue: {second: '15'}},
     });
-    expect(memento.get(key)).toEqual({second: 15});
+    expect(memento.get(key)).toEqual({second: '15'});
 
     webview.postWebviewMessage({
       command: 'webviewStateChanged',


### PR DESCRIPTION
Fixes #11.
binary_plist_decoder.ts > parseAsDate was using
Date.setSeconds() and Date.getSeconds(), which
gets and sets the seconds according to local
time. This caused incorrect date parsing.